### PR TITLE
Upgraded 'svgicons2svgfont' version to fix errors when using Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "4.17.5",
     "postcss": "6.0.20",
     "svg2ttf": "4.1.0",
-    "svgicons2svgfont": "9.0.2",
+    "svgicons2svgfont": "9.0.3",
     "ttf2woff": "2.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi,

just a really simple PR that fixes an error I encountered when using iconfont-webpack-plugin with Node 10, where it always threw the following error:

```
(node:11196) UnhandledPromiseRejectionWarning: TypeError: Cannot create property 'message' on string 'Checksum error in glyf'
    at iconfont-webpack-plugin/lib/loader.js:34:19
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

The `Checksum error in glyf` was fixed in nfroidure/svg-pathdata#33 which in turn was upgraded in svgicons2svgfont version 9.0.3.

Cheers,
Benjamin