### PR TITLE
Fixes #30: Add postcss-loader 3 support to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "webpack": "*",
-    "postcss-loader": "^2.1.3"
+    "postcss-loader": "^2.1.3 || ^3.0.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Fixes issue #30.

Checking postcss-loader, only reason it is a breaking change was because they drop support for node < 6. I doubt there is anything we need to worry about in here though.