### PR TITLE
Add `enforcedTimestamp` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Probably you won't need this but you can also pass some additional options.
 |**`resolve`**|`{Function}`||Required - A function which resolves the svg paths. See [resolve](https://webpack.js.org/api/loaders/#this-resolve)|
 |**`fontNamePrefix`**|`{String}`|`''`| Allows to prefix the generated font name |
 |**`enforcedSvgHeight`**|`{number}`|`1000`| Scales all svg to the given height |
+|**`enforcedTimestamp`**|`{number}`|| Overwrites the UNIX timestamp in the TTF font conversion step. This way, every build will give you exactly the same result.
 
 ```js
 const IconfontWebpackPlugin = require('iconfont-webpack-plugin');
@@ -89,6 +90,7 @@ const IconfontWebpackPlugin = require('iconfont-webpack-plugin');
                     resolve: loader.resolve,
                     fontNamePrefix: 'custom-',
                     enforcedSvgHeight: 3000,
+                    enforcedTimestamp: 1528942455
                   })
                 ]
               };
@@ -187,4 +189,3 @@ We tried to apply best practices to solve the main issues for you.
 # License
 
 This project is licensed under [MIT](https://github.com/jantimon/iconfont-webpack-plugin/blob/master/LICENSE).
-

--- a/lib/icons-to-woff.js
+++ b/lib/icons-to-woff.js
@@ -10,7 +10,7 @@ const Readable = require('stream').Readable;
 /**
  * @param  {typeof import("fs")} fs  An input file system
  * @param  {String[]} icons Array of icon file paths
- * @param  {{name: string, enforcedSvgHeight?: number}} options SVG-Font options
+ * @param  {{name: string, enforcedSvgHeight?: number, enforcedTimestamp?: number}} options SVG-Font options
  * @return {Promise<String>} Base64 encoded font
  */
 module.exports = function createIconFont (fs, icons, options) {
@@ -58,7 +58,7 @@ module.exports = function createIconFont (fs, icons, options) {
     });
     fontStream.end();
   })
-    .then((svgFont) => svg2ttf(svgFont, {}).buffer)
+    .then((svgFont) => svg2ttf(svgFont, {ts: options.enforcedTimestamp ? options.enforcedTimestamp : undefined}).buffer)
     .then((ttfFont) => ttf2woff(ttfFont).buffer)
     .then((woffFont) => Buffer.from(woffFont).toString('base64'));
 };

--- a/lib/postcss-plugin.js
+++ b/lib/postcss-plugin.js
@@ -148,10 +148,11 @@ function replaceIconFontDeclarations (fontName, postCssRoot, svgPaths) {
  * @param postCssRoot {any} The postCss root object
  * @param enforcedSvgHeight {number} the enforced height of the svg font
  * @param svgPaths {SvgPaths} The svg path information
+ * @param enforcedTimestamp {Number} Unix timestamp to replace a generated one in the TTF conversion step.
  */
-function addFontDeclaration (fontName, postCssRoot, enforcedSvgHeight, svgPaths) {
+function addFontDeclaration (fontName, postCssRoot, enforcedSvgHeight, svgPaths, enforcedTimestamp) {
   // The options are passed as a query string so we use the relative svg paths to reduce the path length per file
-  const options = { svgs: svgPaths.relative, name: fontName, enforcedSvgHeight: enforcedSvgHeight };
+  const options = { svgs: svgPaths.relative, name: fontName, enforcedSvgHeight: enforcedSvgHeight, enforcedTimestamp };
   // Resolve the icon font plugin directoy in case the iconfont-webpack-plugin is used as a sub dependency
   const iconFontPluginDirectory = path.dirname(require.resolve('../'));
   // Use paths always with slash also for win32 to prevent an issues with resolving the placeholder on windows
@@ -193,7 +194,7 @@ module.exports = postcss.plugin('iconfont-webpack', config => function (root, re
       // Update the css
       const processCssPromise = Promise.all([
         // add the font faces
-        addFontDeclaration(fontName, root, config.enforcedSvgHeight, svgPaths),
+        addFontDeclaration(fontName, root, config.enforcedSvgHeight, svgPaths, config.enforcedTimestamp),
         // replace the `font-icon` occurences
         replaceIconFontDeclarations(fontName, root, svgPaths)
       ]);


### PR DESCRIPTION
I use a modified version of your plugin ([zner0L/postcss-fonticons](https://github.com/zner0L/postcss-fonticons)) and ran into a problem, because the generated CSS was a little different every time it was built. This was bad for caching, since those little changes still invalidated the caches. After some digging, I found that the changing bits were actually `svg2ttf`'s timestamps in the generated fonts. This PR exposes their option to overwrite timestamps to get dependable results in every build.