### PR TITLE
fix(icons-to-woff.js): enforce deterministic output

### DIFF
--- a/lib/icons-to-woff.js
+++ b/lib/icons-to-woff.js
@@ -21,10 +21,7 @@ module.exports = function createIconFont (fs, icons, options) {
       name: options.name,
       normalize: true,
       fontHeight: options.enforcedSvgHeight ? options.enforcedSvgHeight : undefined,
-      log: function () {},
-      error: /** @param {any} err */function (err) {
-        reject(err);
-      }
+      log: function () {}
     });
     let svgFont = '';
     fontStream
@@ -58,7 +55,7 @@ module.exports = function createIconFont (fs, icons, options) {
     });
     fontStream.end();
   })
-    .then((svgFont) => svg2ttf(svgFont, {}).buffer)
+    .then((svgFont) => svg2ttf(svgFont, { ts: 0 }).buffer)
     .then((ttfFont) => ttf2woff(ttfFont).buffer)
     .then((woffFont) => Buffer.from(woffFont).toString('base64'));
 };

--- a/test/fixtures/malformed.svg
+++ b/test/fixtures/malformed.svg
@@ -1,0 +1,1 @@
+I am not an SVG.

--- a/test/icons-to-woff.js
+++ b/test/icons-to-woff.js
@@ -1,0 +1,77 @@
+'use strict';
+/* eslint max-len: off, quotes:off, arrow-parens:off */
+import createIconFont from '../lib/icons-to-woff.js';
+import fs from 'fs';
+import test from 'ava';
+
+test('should throw an error when an svg cannot be found', async (t) => {
+  let error;
+  try {
+    await createIconFont(fs, [
+      './test/fixtures/does-not-exist.svg'
+    ], {
+      name: 'test'
+    });
+  } catch (e) {
+    error = e.message;
+  }
+
+  t.is(error.substring(0, 33), 'ENOENT: no such file or directory');
+  t.pass();
+});
+
+test('should throw an error when a malformed svg is provided', async (t) => {
+  let error;
+  try {
+    await createIconFont(fs, [
+      './test/fixtures/malformed.svg'
+    ], {
+      name: 'test'
+    });
+  } catch (e) {
+    error = e.message;
+  }
+
+  t.is(error.substring(0, 32), 'Non-whitespace before first tag.');
+  t.pass();
+});
+
+test('should produce the same output when receiving the same input and configuration', async (t) => {
+  const svgs = [
+    './test/fixtures/account-494x512.svg',
+    './test/fixtures/account-986x1024.svg'
+  ];
+
+  const test1 = await createIconFont(fs, svgs, {
+    name: 'test'
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const test2 = await createIconFont(fs, svgs, {
+    name: 'test'
+  });
+
+  t.is(test1, test2);
+  t.pass();
+});
+
+test('should produce different output when receiving the same input but different fontHeight', async (t) => {
+  const svgs = [
+    './test/fixtures/account-494x512.svg',
+    './test/fixtures/account-986x1024.svg'
+  ];
+
+  const test1 = await createIconFont(fs, svgs, {
+    enforcedSvgHeight: 32
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const test2 = await createIconFont(fs, svgs, {
+    enforcedSvgHeight: 16
+  });
+
+  t.not(test1, test2);
+  t.pass();
+});


### PR DESCRIPTION
Ensure builds with the same set of inputs results in an identical font hash for deterministic builds.

Improves solution proposed in #53

Notes:
* Added unit test coverage to `icons-to-woff.js` to verify this fix actually worked. Needed to write a few additional tests to ensure 100% coverage of that file.
* `error` option passed to `Svgicons2svgfont` was removed because it's not a supported property of that project. This issue was highlighted when unit test coverage was added to `icons-to-woff.js` and the line coverage could not be met.