### PR TITLE
Webpack should't append hostname to @font-face src:url($url)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -26,11 +26,11 @@ module.exports = function () {
   createIconFont(this._compiler.inputFileSystem, query.svgs, query)
     .then((result) => {
       // Return the font to webpack
-      const url = '"data:application/x-font-woff;charset=utf-8;base64,' + result + '"';
+      const url = 'data:application/x-font-woff;charset=utf-8;base64,' + result;
       callback(null, 'module.exports=' + JSON.stringify(url) + ';');
     }, function (err) {
       // In case of an svg generation error return an invalid font and throw an error
-      const url = '"data:application/x-font-woff;charset=utf-8;base64,"';
+      const url = 'data:application/x-font-woff;charset=utf-8;base64,';
       err.message += ' - Tried to compile: ' + JSON.stringify(query.svgs, null, 2);
       callback(new Error(err), 'module.exports=' + JSON.stringify(url) + ';');
     });


### PR DESCRIPTION
Currently webpack is adding hostname in-front of `data:` URLs because it thinks that it's a path given that it starts with `"data:` and not `data:`.

Attaching Screenshots of the issue:

With Change
<img width="1280" alt="with-change" src="https://github.com/jantimon/iconfont-webpack-plugin/assets/19840705/a7e66552-3ef8-4e35-9ecd-f5e939b70098">


Without Change
<img width="1280" alt="without-change" src="https://github.com/jantimon/iconfont-webpack-plugin/assets/19840705/7c78304b-6d97-46fe-9c51-a0f11d237049">
